### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	include implementation("com.moulberry:mixinconstraints:1.0.1")
-	include implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6"))
+	include implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6"))
 	modImplementation annotationProcessor("net.rotgruengelb:nixienaut:${project.nixienaut_version}")
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	include implementation("com.moulberry:mixinconstraints:1.0.1")
-	include implementation(annotationProcessor("com.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0-beta.6"))
+	include implementation(annotationProcessor("com.github.bawnorton:mixinsquared-fabric:0.2.0-beta.6"))
 	modImplementation annotationProcessor("net.rotgruengelb:nixienaut:${project.nixienaut_version}")
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.4+build.3
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=0.0.1
+mod_version=0.0.2
 maven_group=net.rotgruengelb
 archives_base_name=rbbg
 


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_